### PR TITLE
bug fix and add non root version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,10 @@ CMD \
     echo "***** App directory contains a requirements.txt file, installing npm requirements *****"; \
     cat /app/requirements.txt | xargs npm --prefer-offline install --save; \
   fi; \
+  if [ ! -d "/app/.ssh" ]; then \
+    echo "***** /app/.ssh does not exist, directory is made *****"; \
+    mkdir -p /app/.ssh; \
+  fi; \
   if [ "$(ls -A /app/.ssh 2>/dev/null)" ]; then \
     echo "***** App .ssh directory exists and has content, continuing *****"; \
   else \

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Later, you can pull from dockerhub.
 
 ## Getting Started
 
-**ROOT MODE (DEFAULT)**
+### ROOT MODE (DEFAULT)
 
 Create a new blog container, substitute *domain.com* for your domain and specify your blog location with -v target:/app, specify your git user and email address (for deployment):
 
@@ -48,7 +48,7 @@ docker start hexo-domain.com
 ```
 
 
-**NON-ROOT MODE (PC USERS)**
+### NON-ROOT MODE (PC USERS)
 
 Create a new blog container, substitute *domain.com* for your domain and specify your blog location with -v target:/home/node/app, specify your git user and email address (for deployment):
 

--- a/README.md
+++ b/README.md
@@ -13,21 +13,30 @@ A tutorial is available at [spurin.com](https://spurin.com/2020/01/04/Creating-a
 
 Latest update locks the node version to 13-slim rather than slim (which at the time of writing is 14), whilst Hexo appears to work for most areas, there is at present an outstanding issue that prevents the `hexo deploy` working with 14.  See [Hexo 4275]( https://github.com/hexojs/hexo/issues/4275)
 
+TODO AND NOTICE: 
+
+Now the default Dockerfile is still root user for compatible issue, but you should migrate to non-root for security and convenience if you are a PC user. If you currently want to run one, build an image yourself. I will push it to Dockerhub and change the description there as soon as possible so that you can pull from there. BUT migrating to non-root user version will surely **CAUSE COMPATIBLE ISSUES**, so read the description page.
+
+Command line is as follows:
+```
+docker build -t hexo:nonroot -f hexo_nonroot.Dockerfile .
+```
+
 ## Getting Started
 
-Create a new blog container, substitute *domain.com* for your domain and specify your blog location with -v target:/app, specify your git user and email address (for deployment):
+Create a new blog container, substitute *domain.com* for your domain and specify your blog location with -v target:/home/node/app, specify your git user and email address (for deployment):
 
 ```
 docker create --name=hexo-domain.com \
 -e HEXO_SERVER_PORT=4000 \
 -e GIT_USER="Your Name" \
 -e GIT_EMAIL="your.email@domain.tld" \
--v /blog/domain.com:/app \
+-v ~/blog/domain.com:/home/node/app \
 -p 4000:4000 \
-spurin/hexo
+spurin/hexo:nonroot
 ```
 
-If a blog is not configured in /app (locally as /blog/domain.com) already, it will be created and Hexo-Admin will be installed into the blog as the container is started
+If a blog is not configured in /home/node/app (locally as /blog/domain.com) already, it will be created and Hexo-Admin will be installed into the blog as the container is started
 
 ```
 docker start hexo-domain.com
@@ -53,8 +62,47 @@ docker logs --follow hexo-domain.com
 
 Each theme will vary but for example, a theme such as [Hueman](https://github.com/ppoffice/hexo-theme-hueman), clone the repository to the themes directory within the app volume
 
+#### Execute outside container
+
+Non-root access is the key feature of this update so that you can control your app volume outside the container. 
+
 ```
-cd /app
+cd ~/blog/domain.com
+git clone https://github.com/ppoffice/hexo-theme-hueman.git themes/hueman
+```
+
+Update _config.yml in your app folder, and change theme accordingly
+
+```
+theme: hueman
+```
+
+Enable the default configuration
+
+```
+mv themes/hueman/_config.yml.example themes/hueman/_config.yml
+```
+
+And restart the container
+
+```
+docker restart hexo-domain.com
+```
+
+
+
+#### Execute inside container
+
+If you want to operate the way before, access the container running the commmand line as follows:
+
+```
+docker exec -it hexo-domain.com bash
+```
+
+You can operate in the similar way as before
+
+```
+cd /home/node/app
 git clone https://github.com/ppoffice/hexo-theme-hueman.git themes/hueman
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,20 +13,48 @@ A tutorial is available at [spurin.com](https://spurin.com/2020/01/04/Creating-a
 
 Latest update locks the node version to 13-slim rather than slim (which at the time of writing is 14), whilst Hexo appears to work for most areas, there is at present an outstanding issue that prevents the `hexo deploy` working with 14.  See [Hexo 4275]( https://github.com/hexojs/hexo/issues/4275)
 
-TODO AND NOTICE: 
+## TODO AND NOTICE: 
 
-Now the default Dockerfile is still root user for compatible issue, but you should migrate to non-root for security and convenience if you are a PC user. If you currently want to run one, build an image yourself. I will push it to Dockerhub and change the description there as soon as possible so that you can pull from there. BUT migrating to non-root user version will surely **CAUSE COMPATIBLE ISSUES**, so read the description page.
+Now the default Dockerfile is still root user for compatible issue for **server maintainers**, especially for those whose server **have no non-root user**. But you should migrate to non-root version if you are a **PC user**, for it is secure and convenient to edit files in app volume. BUT migrating to non-root version directly will surely **CAUSE COMPATIBLE ISSUES**, so read the description page.
 
-Command line is as follows:
+If you currently want to run one, build an image yourself. I will push it to Dockerhub and change the description there as soon as possible so that you can pull from there:
+
 ```
 docker build -t hexo:nonroot -f hexo_nonroot.Dockerfile .
 ```
+Later, you can pull from dockerhub.
+
 
 ## Getting Started
+
+**ROOT MODE (DEFAULT)**
+
+Create a new blog container, substitute *domain.com* for your domain and specify your blog location with -v target:/app, specify your git user and email address (for deployment):
+
+```
+docker create --name=hexo-domain.com \
+-e HEXO_SERVER_PORT=4000 \
+-e GIT_USER="Your Name" \
+-e GIT_EMAIL="your.email@domain.tld" \
+-v /blog/domain.com:/app \
+-p 4000:4000 \
+spurin/hexo
+```
+
+If a blog is not configured in /app (locally as /blog/domain.com) yet, it will be created and Hexo-Admin will be installed into the blog as the container is started
+
+```
+docker start hexo-domain.com
+```
+
+
+**NON-ROOT MODE (PC USERS)**
 
 Create a new blog container, substitute *domain.com* for your domain and specify your blog location with -v target:/home/node/app, specify your git user and email address (for deployment):
 
 ```
+mkdir -p ~/blog/domain.com
+
 docker create --name=hexo-domain.com \
 -e HEXO_SERVER_PORT=4000 \
 -e GIT_USER="Your Name" \
@@ -36,7 +64,7 @@ docker create --name=hexo-domain.com \
 spurin/hexo:nonroot
 ```
 
-If a blog is not configured in /home/node/app (locally as /blog/domain.com) already, it will be created and Hexo-Admin will be installed into the blog as the container is started
+If a blog is not configured in /home/node/app (locally as ~/blog/domain.com) yet, it will be created and Hexo-Admin will be installed into the blog as the container is started
 
 ```
 docker start hexo-domain.com
@@ -62,47 +90,18 @@ docker logs --follow hexo-domain.com
 
 Each theme will vary but for example, a theme such as [Hueman](https://github.com/ppoffice/hexo-theme-hueman), clone the repository to the themes directory within the app volume
 
-#### Execute outside container
-
-Non-root access is the key feature of this update so that you can control your app volume outside the container. 
-
-```
-cd ~/blog/domain.com
-git clone https://github.com/ppoffice/hexo-theme-hueman.git themes/hueman
-```
-
-Update _config.yml in your app folder, and change theme accordingly
-
-```
-theme: hueman
-```
-
-Enable the default configuration
-
-```
-mv themes/hueman/_config.yml.example themes/hueman/_config.yml
-```
-
-And restart the container
-
-```
-docker restart hexo-domain.com
-```
-
-
-
 #### Execute inside container
 
-If you want to operate the way before, access the container running the commmand line as follows:
+Run this commmand line to access the container:
 
 ```
 docker exec -it hexo-domain.com bash
 ```
 
-You can operate in the similar way as before
+Inside the container:
 
 ```
-cd /home/node/app
+cd /app
 git clone https://github.com/ppoffice/hexo-theme-hueman.git themes/hueman
 ```
 
@@ -130,13 +129,47 @@ And restart the container
 docker restart hexo-domain.com
 ```
 
+
+#### Execute outside container (non-root version only)
+
+Non-root access is the key feature of this update so that you can control your app volume outside the container, steps are quite the similar but more convenient:
+
+```
+cd ~/blog/domain.com
+git clone https://github.com/ppoffice/hexo-theme-hueman.git themes/hueman
+```
+
+Update _config.yml in your app folder, and change theme accordingly
+
+```
+theme: hueman
+```
+
+Enable the default configuration
+
+```
+mv themes/hueman/_config.yml.example themes/hueman/_config.yml
+```
+
+And restart the container
+
+```
+docker restart hexo-domain.com
+```
+
+It is OK to follow the similar way as in the default version before, by just replacing `cd /app` with `cd /home/node/app`.
+
 ## Accessing Hexo
 
-Access the default hexo blog interface at http://< ip_address >:4000
+Access the default hexo blog interface at `http://< ip_address >:4000`
+
+If you are a PC user, visit `localhost:4000`
 
 ## Accessing Hexo-Admin
 
-Access Hexo-Admin at http://< ip_address >:4000/admin
+Access Hexo-Admin at `http://< ip_address >:4000/admin`
+
+PC user, `localhost:4000`
 
 ## Generating Content
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Dockerfile for [Hexo](https://hexo.io/) with [Hexo Admin](https://github.com/jar
 
 The image is available directly from [Docker Hub](https://hub.docker.com/r/spurin/hexo/)
 
-A tutorial is available at [spurin.com](https://spurin.com/2020/01/04/Creating-a-Blog-Website-with-Docker-Hexo-Github-Free-Hosting-and-HTTPS/)
+A tutorial is available at [spurin.com](https://spurin.com/old/2020/01/04/Creating-a-Blog-Website-with-Docker-Hexo-Github-Free-Hosting-and-HTTPS/)
 
-Latest update locks the node version to 13-slim rather than slim (which at the time of writing is 14), whilst Hexo appears to work for most areas, there is at present an outstanding issue that prevents the `hexo deploy` working with 14.  See [Hexo 4275]( https://github.com/hexojs/hexo/issues/4275)
+Latest version updates the node version from 13-slim to 20-bullseye.
 
 ## TODO AND NOTICE: 
 

--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ Deployment keys are configured as part of the initial app configuration, see the
 docker logs --follow hexo-domain.com
 ```
 
-### Installing a theme
+## Installing a theme
 
 Each theme will vary but for example, a theme such as [Hueman](https://github.com/ppoffice/hexo-theme-hueman), clone the repository to the themes directory within the app volume
 
-#### Execute inside container
+### Execute inside container
 
 Run this commmand line to access the container:
 
@@ -130,7 +130,7 @@ docker restart hexo-domain.com
 ```
 
 
-#### Execute outside container (non-root version only)
+### Execute outside container (non-root version only)
 
 Non-root access is the key feature of this update so that you can control your app volume outside the container, steps are quite the similar but more convenient:
 

--- a/hexo_nonroot.Dockerfile
+++ b/hexo_nonroot.Dockerfile
@@ -1,0 +1,68 @@
+FROM node:20-bullseye
+
+MAINTAINER James Spurin <james@spurin.com>
+
+# Set the server port as an environmental
+ENV HEXO_SERVER_PORT=4000
+
+# Set the git username and email
+ENV GIT_USER="Joe Bloggs"
+ENV GIT_EMAIL="joe@bloggs.com"
+
+# Install requirements
+RUN \
+ apt-get update && \
+ apt-get install git -y && \
+ npm install -g hexo-cli
+
+# Add non-root user
+USER node
+
+# Set workdir
+WORKDIR /home/node/app
+
+# Expose Server Port
+EXPOSE ${HEXO_SERVER_PORT}
+
+# Build a base server and configuration if it doesnt exist, then start
+CMD \
+  if [ "$(ls -A /home/node/app)" ]; then \
+    echo "***** App directory exists and has content, continuing *****"; \
+  else \
+    echo "***** App directory is empty, initialising with hexo and hexo-admin *****" && \
+    hexo init && \
+    npm install && \
+    npm install --save hexo-admin; \
+  fi; \
+  if [ ! -f /home/node/app/requirements.txt ]; then \
+    echo "***** App directory contains no requirements.txt file, continuing *****"; \
+  else \
+    echo "***** App directory contains a requirements.txt file, installing npm requirements *****"; \
+    cat /home/node/app/requirements.txt | xargs npm --prefer-offline install --save; \
+  fi; \
+  if [ ! -d "/home/node/app/.ssh" ]; then \
+    echo "***** directory ~/.ssh does not exist, making one right away *****"; \
+    mkdir -p /home/node/app/.ssh; \
+  fi; \
+  if [ "$(ls -A /home/node/app/.ssh 2>/dev/null)" ]; then \
+    echo "***** App .ssh directory exists and has content, continuing *****"; \
+  else \
+    echo "***** App .ssh directory is empty, initialising ssh key and configuring known_hosts for common git repositories (github/gitlab) *****" && \
+    rm -rf ~/.ssh/* && \
+    ssh-keygen -t rsa -f ~/.ssh/id_rsa -q -P "" && \
+    ssh-keyscan github.com > ~/.ssh/known_hosts 2>/dev/null && \
+    ssh-keyscan gitlab.com >> ~/.ssh/known_hosts 2>/dev/null && \
+    cp -r ~/.ssh /home/node/app; \
+  fi; \
+  echo "***** Running git config, user = ${GIT_USER}, email = ${GIT_EMAIL} *****" && \
+  git config --global user.email ${GIT_EMAIL} && \
+  git config --global user.name ${GIT_USER} && \
+  echo "***** Copying .ssh from App directory and setting permissions *****" && \
+  cp -r /home/node/app/.ssh ~/ && \
+  chmod 600 ~/.ssh/id_rsa && \
+  chmod 600 ~/.ssh/id_rsa.pub && \
+  chmod 700 ~/.ssh && \
+  echo "***** Contents of public ssh key (for deploy) - *****" && \
+  cat ~/.ssh/id_rsa.pub && \
+  echo "***** Starting server on port ${HEXO_SERVER_PORT} *****" && \
+  hexo server -d -p ${HEXO_SERVER_PORT}


### PR DESCRIPTION
Hi. 

There is something that you need to do yourself. Build and push another two images to docker hub named `spurin/hexo:latest` and `spurin/hexo:nonroot` and edit the README.md in the TODO AND NOTICE part. I've written them in the TODO AND NOTICE in the README.md file. 

Earlier I have made a pull request that fix a tiny bug and switch root mode into non-root mode, but I realized some compatible issues, for the working directory has to be changed into a longer one to use non-root mode. Considering that most of the users are server users, especially for those beginners, it is OK and more convenient for them to use root mode directly, because most of their servers have the only root user. And for those server maintainers, compatible issues can cause huge problems or even financial loss, so I just cancelled and kept the root mode.